### PR TITLE
[S] Print more detailed output

### DIFF
--- a/src/violations.rs
+++ b/src/violations.rs
@@ -4,6 +4,7 @@ use std::{collections::HashMap, hash::Hash, hash::Hasher};
 pub struct Violation {
     pub file_path: String,
     pub disallowed_import: String,
+    pub full_disallowed_import: String,
 }
 
 impl Hash for Violation {
@@ -27,18 +28,36 @@ where
 {
     // Cluster violations by file path
     let mut disallowed_imports_by_file_path: HashMap<String, Vec<String>> = HashMap::new();
+    let mut full_disallowed_imports_by_file_path_plus_disallowed_import: HashMap<
+        String,
+        Vec<String>,
+    > = HashMap::new();
 
     for violation in violations {
+        let key = format!("{}:{}", violation.file_path, violation.disallowed_import);
         disallowed_imports_by_file_path
-            .entry(violation.file_path.clone())
+            .entry(violation.file_path)
             .or_default()
             .push(violation.disallowed_import);
+        full_disallowed_imports_by_file_path_plus_disallowed_import
+            .entry(key)
+            .or_default()
+            .push(violation.full_disallowed_import);
     }
 
     for (file_path, disallowed_imports) in disallowed_imports_by_file_path {
         println!("{}", file_path);
         for disallowed_import in disallowed_imports {
-            println!("  {} is disallowed", disallowed_import);
+            let key = format!("{}:{}", file_path, disallowed_import);
+            println!("  imports disallowed path {}", disallowed_import);
+            let full_disallowed_imports =
+                full_disallowed_imports_by_file_path_plus_disallowed_import
+                    .get(&key)
+                    .expect("full_disallowed_imports_by_file_path_plus_disallowed_imports");
+            for full_disallowed_import in full_disallowed_imports {
+                println!("     {}", full_disallowed_import);
+            }
         }
+        println!();
     }
 }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -55,6 +55,7 @@ fn check_files_for_disallowed_imports(
                     let violation = Violation {
                         file_path: relative_path.to_str().expect("").to_string(),
                         disallowed_import: disallowed_import.clone(),
+                        full_disallowed_import: import.clone(),
                     };
                     violations.push(violation);
                     if abort_on_violation {


### PR DESCRIPTION
```
% cargo run lint ~/loop/backend/src 
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/ts_deplint lint /Users/max/loop/backend/src`
src/domain/rating/rate-engine/internal/loop-parcel-rate-engine/loop-parcel-rate-engine.service.ts
  imports disallowed path src/domain/parcel/
     src/domain/parcel/parcel-customer-carrier-account/query/parcel-customer-carrier-account.loader.service

src/domain/rating/rate-engine/internal/loop-parcel-rate-engine/loop-parcel-rate-engine.module.ts
  imports disallowed path src/domain/parcel/
     src/domain/parcel/parcel-customer-carrier-account/parcel-customer-carrier-account.module

Error: "2 violations."
```