### PR TITLE
finding + fixing references to non-existent directories in rules

### DIFF
--- a/src/disallowed.rs
+++ b/src/disallowed.rs
@@ -55,11 +55,12 @@ fn get_initial_disallowed_imports_impl(
         .nth(0)
         .and_then(|component| component.as_os_str().to_str().map(String::from))
         .expect("Failed to read next directory name.");
+    let (rules, _) = &rules::get_dir_rules_if_exists(current);
     let child_disallowed_imports = get_child_disallowed_imports(
         root,
         current,
         &disallowed_imports,
-        &rules::get_dir_rules(current),
+        rules,
         &next_dir_name,
     );
     return get_initial_disallowed_imports_impl(

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -1,9 +1,15 @@
 use std::path::Path;
 
-use crate::rules::{read_rules_file, write_formatted_rules_file};
-use crate::{Violation, RULES_FILE_NAME};
+use crate::{
+    rules::{read_rules_file, write_formatted_rules_file},
+    violations::ReferenceToNonexistentDirectory,
+    DisallowedImportViolation, RULES_FILE_NAME,
+};
 
-pub fn fix_violation(root: &Path, violation: &Violation) -> Result<(), Box<dyn std::error::Error>> {
+pub fn fix_violation(
+    root: &Path,
+    violation: &DisallowedImportViolation,
+) -> Result<(), Box<dyn std::error::Error>> {
     let file_path = &violation.file_path;
     let disallowed_import = &violation.disallowed_import;
     let mut common_prefix = file_path
@@ -27,8 +33,7 @@ pub fn fix_violation(root: &Path, violation: &Violation) -> Result<(), Box<dyn s
         .take_while(|c| *c != '/')
         .collect::<String>();
     let rules_path = root.join(common_prefix).join(RULES_FILE_NAME);
-    let rules = read_rules_file(&rules_path)?;
-    let mut rules = rules;
+    let mut rules = read_rules_file(&rules_path)?;
     let mut allow = rules.allow;
     let disallowed_imports = allow
         .entry(dir_after_common_prefix)
@@ -38,5 +43,31 @@ pub fn fix_violation(root: &Path, violation: &Violation) -> Result<(), Box<dyn s
     disallowed_imports.sort();
     disallowed_imports.dedup();
     rules.allow = allow;
-    return write_formatted_rules_file(&rules_path, rules);
+    write_formatted_rules_file(&rules_path, rules)
+}
+
+pub fn remove_reference_to_nonexistent_directory(
+    root: &Path,
+    issue: &ReferenceToNonexistentDirectory,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let rules_file_path = Path::new(&issue.rules_file_path);
+    let mut rules = read_rules_file(rules_file_path)?;
+    rules.allow = rules
+        .allow
+        .into_iter()
+        .flat_map(|(source, targets)| {
+            if source == issue.directory_name {
+                None
+            } else {
+                Some((
+                    source,
+                    targets
+                        .into_iter()
+                        .filter(|target| target != &issue.directory_name)
+                        .collect(),
+                ))
+            }
+        })
+        .collect();
+    write_formatted_rules_file(rules_file_path, rules)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,13 +13,12 @@ mod visit;
 
 pub use diagram::update_diagrams_recursively;
 pub use diagram::update_readme_with_diagram;
-pub use fix::fix_violation;
+pub use fix::{fix_violation, remove_reference_to_nonexistent_directory};
 pub use format::format_rules_file;
 pub use format::format_rules_files_recursively;
 pub use root::find_package_json_directory;
 pub use rules::RULES_FILE_NAME;
-pub use violations::pretty_print_violations;
-pub use violations::Violation;
+pub use violations::{pretty_print_violations, DisallowedImportViolation, Violation};
 
 pub fn list_violations(
     root: &Path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,14 @@ fn run_fix_command(command: FixCommand) -> Result<(), Box<dyn Error>> {
                 break;
             }
             for violation in violations {
-                ts_deplint::fix_violation(&root, &violation)?;
+                match violation {
+                    Violation::DisallowedImportViolation(violation) => {
+                        ts_deplint::fix_violation(&root, &violation)?;
+                    }
+                    Violation::ReferenceToNonexistentDirectory(issue) => {
+                        ts_deplint::remove_reference_to_nonexistent_directory(&root, &issue)?;
+                    }
+                }
             }
             i += 1;
             if i > 500 {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -1,4 +1,7 @@
-use crate::{disallowed, files, rules, ts_reader, violations::Violation};
+use crate::{
+    disallowed, files, rules, ts_reader,
+    violations::{DisallowedImportViolation, Violation},
+};
 use std::{error::Error, path::Path};
 
 pub fn visit_path(
@@ -52,12 +55,12 @@ fn check_files_for_disallowed_imports(
         for import in imports {
             for disallowed_import in disallowed_imports {
                 if import.starts_with(disallowed_import) {
-                    let violation = Violation {
+                    let violation = DisallowedImportViolation {
                         file_path: relative_path.to_str().expect("").to_string(),
                         disallowed_import: disallowed_import.clone(),
                         full_disallowed_import: import.clone(),
                     };
-                    violations.push(violation);
+                    violations.push(Violation::DisallowedImportViolation(violation));
                     if abort_on_violation {
                         return Ok(());
                     }
@@ -77,7 +80,12 @@ fn visit_directories(
     directories: &Vec<String>,
     abort_on_violation: bool,
 ) -> Result<(), Box<dyn Error>> {
-    let current_rules = rules::get_dir_rules(current);
+    let (current_rules, rules_file_violations) = rules::get_dir_rules_if_exists(current);
+    violations.extend(
+        rules_file_violations
+            .into_iter()
+            .map(|issue| Violation::ReferenceToNonexistentDirectory(issue)),
+    );
     for child in directories {
         let dir_disallowed_imports = disallowed::get_child_disallowed_imports(
             root,


### PR DESCRIPTION
For #9, non-existing directories are listed as violations with `lint`, and can be fixed with the `fix` command.