### PR TITLE
[S] Setup Renovate with auto-merge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check formatting
         run: cargo fmt --check
       - name: Clippy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check formatting
+        run: cargo fmt --check
+      - name: Clippy
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,5 +27,3 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check formatting
         run: cargo fmt --check
-      - name: Clippy
-        run: cargo clippy -- -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,3 +27,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check formatting
         run: cargo fmt --check
+      - name: Clippy
+        run: cargo clippy -- -D warnings

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "timezone": "America/Los_Angeles",
+  "schedule": ["after 10pm and before 5am every weekday", "every weekend"],
+  "stabilityDays": 3,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    }
+  ]
+}

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -42,7 +42,7 @@ fn get_allows(yaml_path: &Path) -> Result<AllowsMap<String>, Box<dyn Error>> {
     let converted_rules = yaml_rules
         .allow
         .into_iter()
-        .map(|(source, targets)| (source, BTreeSet::from_iter(targets.into_iter())))
+        .map(|(source, targets)| (source, BTreeSet::from_iter(targets)))
         .collect::<AllowsMap<_>>();
     Ok(converted_rules)
 }

--- a/src/disallowed.rs
+++ b/src/disallowed.rs
@@ -56,13 +56,8 @@ fn get_initial_disallowed_imports_impl(
         .and_then(|component| component.as_os_str().to_str().map(String::from))
         .expect("Failed to read next directory name.");
     let (rules, _) = &rules::get_dir_rules_if_exists(root, current);
-    let child_disallowed_imports = get_child_disallowed_imports(
-        root,
-        current,
-        &disallowed_imports,
-        rules,
-        &next_dir_name,
-    );
+    let child_disallowed_imports =
+        get_child_disallowed_imports(root, current, &disallowed_imports, rules, &next_dir_name);
     return get_initial_disallowed_imports_impl(
         root,
         target,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,11 @@ pub fn list_violations(
     target: &Path,
     abort_on_violation: bool,
 ) -> Result<Vec<violations::Violation>, Box<dyn Error>> {
-    let disallowed_imports = disallowed::get_initial_disallowed_imports(&root, target);
+    let disallowed_imports = disallowed::get_initial_disallowed_imports(root, target);
     let mut violations = Vec::new();
     visit::visit_path(
         &mut violations,
-        root.as_ref(),
+        root,
         &disallowed_imports,
         target,
         abort_on_violation,

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ fn run_lint_command(command: LintCommand) -> Result<(), Box<dyn Error>> {
         all_violations.extend(violations);
     }
 
-    if all_violations.len() > 0 {
+    if !all_violations.is_empty() {
         let count = all_violations.len();
         pretty_print_violations(all_violations);
         return Err(format!("{} violations.", count).into());
@@ -128,7 +128,7 @@ fn run_fix_command(command: FixCommand) -> Result<(), Box<dyn Error>> {
                 return Err(format!("Target path '{}' does not exist.", path).into());
             };
             let violations = list_violations(&root, &target, true)?;
-            if violations.len() == 0 {
+            if violations.is_empty() {
                 break;
             }
             for violation in violations {

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -56,7 +56,7 @@ impl Rules {
 fn find_difference<'a>(a: &[&'a str], b: &[&'a str]) -> Vec<&'a str> {
     a.iter()
         .filter(|x| !b.contains(x))
-        .map(|s| *s)
+        .copied()
         .collect::<Vec<&str>>()
 }
 

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -11,7 +11,7 @@ use std::{
 pub fn visit_path(
     violations: &mut Vec<Violation>,
     root: &Path,
-    disallowed_imports: &Vec<String>,
+    disallowed_imports: &[String],
     current: &Path,
     abort_on_violation: bool,
 ) -> Result<(), Box<dyn Error>> {
@@ -44,9 +44,9 @@ pub fn visit_path(
 fn check_files_for_disallowed_imports(
     violations: &mut Vec<Violation>,
     root: &Path,
-    disallowed_imports: &Vec<String>,
+    disallowed_imports: &[String],
     current: &Path,
-    files: &Vec<String>,
+    files: &[String],
     abort_on_violation: bool,
 ) -> Result<(), Box<dyn Error>> {
     for file in files {
@@ -82,9 +82,9 @@ fn check_files_for_disallowed_imports(
 fn visit_directories(
     violations: &mut Vec<Violation>,
     root: &Path,
-    disallowed_imports: &Vec<String>,
+    disallowed_imports: &[String],
     current: &Path,
-    directories: &Vec<String>,
+    directories: &[String],
     abort_on_violation: bool,
 ) -> Result<(), Box<dyn Error>> {
     let (current_rules, rules_file_violations) = rules::get_dir_rules_if_exists(root, current);


### PR DESCRIPTION
## Summary
- Add `renovate.json` with config:base extension
- Auto-merge minor/patch updates (excluding 0.x packages)
- Schedule updates for off-hours (nights/weekends, PST)
- 3-day stability period before auto-merge
- Add CI workflow (`.github/workflows/ci.yaml`) with build, test, and lint checks

## Configuration Details

**renovate.json:**
- `config:base` for sensible defaults
- Auto-merge enabled for minor/patch updates where current version is not 0.x
- Runs during off-hours in America/Los_Angeles timezone
- 3-day stability waiting period

**ci.yaml:**
- Runs on push to main and all PRs
- Build and test job
- Lint job (cargo fmt + clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)